### PR TITLE
fix: disable snappy own tests

### DIFF
--- a/deps/snappy/CMakeLists.txt
+++ b/deps/snappy/CMakeLists.txt
@@ -5,7 +5,7 @@ project(Snappy VERSION 1.1.7 LANGUAGES C CXX)
 # it prominent in the GUI.
 option(BUILD_SHARED_LIBS "Build shared libraries(DLLs)." OFF)
 
-option(SNAPPY_BUILD_TESTS "Build Snappy's own tests." ON)
+option(SNAPPY_BUILD_TESTS "Build Snappy's own tests." OFF)
 
 include(TestBigEndian)
 test_big_endian(SNAPPY_IS_BIG_ENDIAN)


### PR DESCRIPTION
This is preventing the build on current Archlinux:

Excerpt from the build logs (very long):

```
[100%] Linking CXX executable snappy_unittest
/usr/bin/ld: CMakeFiles/snappy_unittest.dir/snappy_unittest.cc.o: in function `snappy::Snappy_ZeroOffsetCopy_Test::TestBody()':
snappy_unittest.cc:(.text+0x6af1): undefined reference to `testing::Message::Message()'
/usr/bin/ld: snappy_unittest.cc:(.text+0x6b1f): undefined reference to `testing::internal::GetBoolAssertionFailureMessage[abi:cxx11](testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: snappy_unittest.cc:(.text+0x6b54): undefined reference to `testing::internal::AssertHelper::AssertHelper(testing::TestPartResult::Type, char const*, int, char const*)'
/usr/bin/ld: snappy_unittest.cc:(.text+0x6b6d): undefined reference to `testing::internal::AssertHelper::operator=(testing::Message const&) const'
/usr/bin/ld: snappy_unittest.cc:(.text+0x6b7c): undefined reference to `testing::internal::AssertHelper::~AssertHelper()'
/usr/bin/ld: snappy_unittest.cc:(.text+0x6bcd): undefined reference to `testing::internal::AssertHelper::~AssertHelper()'
/usr/bin/ld: CMakeFiles/snappy_unittest.dir/snappy_unittest.cc.o: in function `snappy::Snappy_ZeroOffsetCopyValidation_Test::TestBody()':
snappy_unittest.cc:(.text+0x6c96): undefined reference to `testing::Message::Message()'
/usr/bin/ld: snappy_unittest.cc:(.text+0x6cbe): undefined reference to `testing::internal::GetBoolAssertionFailureMessage[abi:cxx11](testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: snappy_unittest.cc:(.text+0x6ced): undefined reference to `testing::internal::AssertHelper::AssertHelper(testing::TestPartResult::Type, char const*, int, char const*)'
/usr/bin/ld: snappy_unittest.cc:(.text+0x6d00): undefined reference to `testing::internal::AssertHelper::operator=(testing::Message const&) const'
/usr/bin/ld: snappy_unittest.cc:(.text+0x6d0c): undefined reference to `testing::internal::AssertHelper::~AssertHelper()'
/usr/bin/ld: snappy_unittest.cc:(.text+0x6d51): undefined reference to `testing::internal::AssertHelper::~AssertHelper()'
/usr/bin/ld: CMakeFiles/snappy_unittest.dir/snappy_unittest.cc.o: in function `snappy::Snappy_FindMatchLength_Test::TestBody()':
snappy_unittest.cc:(.text+0x6ef0): undefined reference to `testing::Message::Message()'
```

