### PR TITLE
fix: include FindZstd

### DIFF
--- a/c_src/CMakeLists.txt
+++ b/c_src/CMakeLists.txt
@@ -132,6 +132,8 @@ if(WITH_SNAPPY)
     find_package(Snappy REQUIRED)
 endif()
 
+include(FindZstd)
+
 if(WITH_ZSTD)
   find_package(Zstd REQUIRED)
 endif()


### PR DESCRIPTION
This script was otherwise not called.  In Archlinux, it leads to a
runtime crash during startup because RocksDB, for some reason,
interprets the default `ROCKSDB_COMPRESSION=true` as to use ZSTD.

A workaround is to start EMQX with `ROCKSDB_COMPRESSION=snappy`, which
is included in the build.