### PR TITLE
ci: release binaries for el9 (rocky linux 9) and macos 12

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,8 +13,8 @@ jobs:
           - 25.1.2-2
           - 24.3.4.2-2
         os:
+          - macos-12
           - macos-11
-          - macos-10.15
     runs-on: ${{ matrix.os }}
     steps:
       - name: prepare
@@ -23,7 +23,7 @@ jobs:
           brew install curl zip unzip gnu-sed kerl
           echo "/usr/local/bin" >> $GITHUB_PATH
           git config --global credential.helper store
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: cache
         with:
           path: ~/.kerl/${{ matrix.otp }}
@@ -37,7 +37,7 @@ jobs:
           kerl build git https://github.com/emqx/otp.git OTP-${{ matrix.otp }} ${{ matrix.otp }}
           kerl install ${{ matrix.otp }} $HOME/.kerl/${{ matrix.otp }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -58,7 +58,7 @@ jobs:
           . $HOME/.kerl/${{ matrix.otp }}/activate
           BUILD_RELEASE=1 make
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: packages
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         builder:
-          - 5.0-28
+          - 5.0-29
         otp:
           - 25.1.2-2
           - 24.3.4.2-2
@@ -88,8 +88,10 @@ jobs:
           - debian11
           - debian10
           - debian9
-          - el7
+          - el9
           - el8
+          - el7
+          - amzn2
           - alpine3.15.1
     runs-on: ubuntu-latest
 
@@ -116,7 +118,7 @@ jobs:
           IMAGE=ghcr.io/emqx/emqx-builder/${{ matrix.builder }}:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
           docker run --user 1001 --rm -v $(pwd):/wd --workdir /wd --platform=linux/${{ matrix.arch }} -e BUILD_RELEASE=1 $IMAGE bash -euc 'make'
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           name: packages
@@ -131,7 +133,7 @@ jobs:
       - linux
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages
           path: packages

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         builder:
-          - 5.0-26
+          - 5.0-29
         otp:
           - 25.1.2-2
         elixir:
@@ -18,10 +18,10 @@ jobs:
           - amd64
           - arm64
         os:
-          - ubuntu20.04
+          - ubuntu22.04
           - debian11
-          - el7
-          - el8
+          - el9
+          - amzn2
           - alpine3.15.1
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
also deprecate macos 10.15