### PR TITLE
ci: remove old distros from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,14 +82,13 @@ jobs:
           - ubuntu22.04
           - ubuntu20.04
           - ubuntu18.04
-          - ubuntu16.04
           - debian12
           - debian11
           - debian10
-          - debian9
           - el9
           - el8
           - el7
+          - amzn2
           - amzn2023
           - alpine3.15.1
     runs-on: ubuntu-latest


### PR DESCRIPTION
To match our current release pipeline in EMQX

https://github.com/emqx/emqx/blob/3902c224e342b26493edbd571ede9f34aa59f8de/.github/workflows/build_packages.yaml#L181-L190