### PR TITLE
chore(build): optimize away build steps if prebuilt binary available

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -1,5 +1,11 @@
 #!/bin/sh -x
 
+if ./do_prebuilt.sh; then
+    exit 0
+else
+    echo "No prebuilt artifacts, building from source"
+fi
+
 mkdir -p _build/cmake
 cd _build/cmake
 

--- a/do_prebuilt.sh
+++ b/do_prebuilt.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -eu
+
+if [ ! -f priv/liberocksdb.so ]; then
+
+PKGNAME="$(./pkgname.sh)"
+if [ "${BUILD_RELEASE:-}" != 1 ] && [ -n "$PKGNAME" ]; then
+    if ./download.sh $PKGNAME; then
+        exit 0
+    else
+        exit 1
+    fi
+fi
+
+fi
+
+# Sanity check
+erlc src/rocksdb.erl
+trap "rm -f rocksdb.beam" EXIT
+if erl -noshell -eval '[_|_]=rocksdb:module_info(), halt(0)'; then
+    exit 0
+else
+    exit 1
+fi

--- a/do_rocksdb.sh
+++ b/do_rocksdb.sh
@@ -3,15 +3,10 @@
 set -eu
 set -x
 
-PKGNAME="$(./pkgname.sh)"
-
-if [ "${BUILD_RELEASE:-}" != 1 ] && [ -n "$PKGNAME" ]; then
-    if ./download.sh $PKGNAME; then
-        echo "done_dowloading_rocksdb"
-        exit 0
-    else
-        echo "failed to download, continue to build from source"
-    fi
+if ./do_prebuilt.sh; then
+    exit 0
+else
+    echo "No prebuilt artifacts, building from source"
 fi
 
 cd _build/cmake

--- a/download.sh
+++ b/download.sh
@@ -8,22 +8,14 @@ URL="https://github.com/emqx/erlang-rocksdb/releases/download/$TAG/$PKGNAME"
 
 mkdir -p _packages
 if [ ! -f "_packages/${PKGNAME}" ]; then
-    curl -f -L -o "_packages/${PKGNAME}" "${URL}"
+    curl -f -L --no-progress-meter -o "_packages/${PKGNAME}" "${URL}"
 fi
 
 if [ ! -f "_packages/${PKGNAME}.sha256" ]; then
-    curl -f -L -o "_packages/${PKGNAME}.sha256" "${URL}.sha256"
+    curl -f -L --no-progress-meter -o "_packages/${PKGNAME}.sha256" "${URL}.sha256"
 fi
 
 echo "$(cat "_packages/${PKGNAME}.sha256") _packages/${PKGNAME}" | sha256sum -c || exit 1
 
+mkdir -p priv
 gzip -c -d "_packages/${PKGNAME}" > priv/liberocksdb.so
-
-erlc src/rocksdb.erl
-if erl -noshell -eval '[_|_]=rocksdb:module_info(), halt(0)'; then
-    res=0
-else
-    res=1
-fi
-rm -f rocksdb.beam
-exit $res


### PR DESCRIPTION
Before this commit, some preparatory build steps were still happening even if a prebuilt binary would have been used later anyway.