### PR TITLE
fix: handle and pass open / write options to rocksdb correctly

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,15 +14,13 @@ jobs:
           - ubuntu22.04
     runs-on: ubuntu-22.04
 
+    container: ghcr.io/emqx/emqx-builder/${{ matrix.builder }}-${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: gitconfig
+        run: git config --system --add safe.directory ${PWD}
       - name: test build
-        env:
-          IMAGE: ghcr.io/emqx/emqx-builder/${{ matrix.builder }}-${{ matrix.os }}
-        run: |
-          docker run --rm -u $UID -v $(pwd):/wd --workdir /wd $IMAGE \
-            bash -euc \
-              'git config --global --add safe.directory /wd; \
-               git config --global --add safe.directory /wd/deps/snappy/third_party/googletest; \
-               git config --global --add safe.directory /wd/deps/snappy/third_party/benchmark; \
-               make'
+        run: make

--- a/c_src/erocksdb_db.cc
+++ b/c_src/erocksdb_db.cc
@@ -1370,6 +1370,8 @@ Put(
     ReferencePtr<DbObject> db_ptr;
     ReferencePtr<erocksdb::ColumnFamilyObject> cf_ptr;
     ErlNifBinary key, value;
+    ERL_NIF_TERM arg_opts;
+
     if(!enif_get_db(env, argv[0], &db_ptr))
         return enif_make_badarg(env);
 
@@ -1382,6 +1384,7 @@ Put(
                 !enif_inspect_binary(env, argv[3], &value))
             return enif_make_badarg(env);
         cfh = cf_ptr->m_ColumnFamily;
+        arg_opts = argv[4];
     }
     else
     {
@@ -1389,9 +1392,10 @@ Put(
                 !enif_inspect_binary(env, argv[2], &value))
             return enif_make_badarg(env);
         cfh = db_ptr->m_Db->DefaultColumnFamily();
+        arg_opts = argv[3];
     }
     rocksdb::WriteOptions *opts = new rocksdb::WriteOptions;
-    fold(env, argv[3], parse_write_option, *opts);
+    fold(env, arg_opts, parse_write_option, *opts);
     rocksdb::Slice key_slice(reinterpret_cast<char*>(key.data), key.size);
     rocksdb::Slice value_slice(reinterpret_cast<char*>(value.data), value.size);
     status = db_ptr->m_Db->Put(*opts, cfh, key_slice, value_slice);

--- a/c_src/erocksdb_db.cc
+++ b/c_src/erocksdb_db.cc
@@ -369,6 +369,10 @@ ERL_NIF_TERM parse_db_option(ErlNifEnv* env, ERL_NIF_TERM item, rocksdb::DBOptio
         {
             opts.atomic_flush = (option[1] == erocksdb::ATOM_TRUE);
         }
+        else if (option[0] == erocksdb::ATOM_MANUAL_WAL_FLUSH)
+        {
+            opts.manual_wal_flush = (option[1] == erocksdb::ATOM_TRUE);
+        }
         else if (option[0] == erocksdb::ATOM_USE_DIRECT_READS)
         {
             opts.use_direct_reads = (option[1] == erocksdb::ATOM_TRUE);

--- a/do_prebuilt.sh
+++ b/do_prebuilt.sh
@@ -16,6 +16,7 @@ if [ ! -f priv/liberocksdb.so ]; then
             exit 1
         fi
     fi
+    exit 2
 fi
 
 # Sanity check


### PR DESCRIPTION
Namely:
* Option `manual_wal_flush` haven't been handled before.
* Write options in `rocksdb:put/5` haven't been handled at all due to them being in another NIF argv.
