### PR TITLE
ci: revert to manually run container builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,6 @@ jobs:
           - alpine3.15.1
 
     runs-on: "aws-${{ matrix.arch }}"
-    container: ghcr.io/emqx/emqx-builder/${{ matrix.builder }}-${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
@@ -104,10 +103,16 @@ jobs:
           submodules: recursive
       - name: gitconfig
         run: git config --global --add safe.directory ${PWD}
+        # NOTE: we tried to use build in container, it did not work
+        #       so let's stick to the old way for now
       - name: build
         env:
-          BUILD_RELEASE: 1
-        run: make
+          IMAGE: ghcr.io/emqx/emqx-builder/${{ matrix.builder }}-${{ matrix.os }}
+        run: >-
+          docker run --rm -v ${PWD}:/wd ${IMAGE} bash -euc "
+          git config --global --add safe.directory '*';
+          make -C /wd BUILD_RELEASE=1
+          "
 
       - uses: actions/upload-artifact@v3
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
This is needed because:
* GHA runner seemingly supplies different, older versions of some build toolsets than those available in the container.
* Alpine container running on arm64 is not compatible with node-based actions.