### PR TITLE
feat(db): allow flushing multiple CFs at once

### DIFF
--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -170,9 +170,9 @@ public:
         }   // if
     };
 
-    TargetT * get() {return(t);};
+    TargetT * get() const { return t; }
 
-    TargetT * operator->() {return(t);};
+    TargetT * operator->() const { return t; }
 };  // ReferencePtr
 
 

--- a/c_src/util.cc
+++ b/c_src/util.cc
@@ -33,6 +33,14 @@ ERL_NIF_TERM error_einval(ErlNifEnv* env)
     return enif_make_tuple2(env, erocksdb::ATOM_ERROR, erocksdb::ATOM_EINVAL);
 }
 
+ERL_NIF_TERM status_to_term(ErlNifEnv* env, rocksdb::Status& status)
+{
+    if (status.ok())
+        return erocksdb::ATOM_OK;
+    else 
+        return error_tuple(env, erocksdb::ATOM_ERROR, status);
+}
+
 ERL_NIF_TERM error_tuple(ErlNifEnv* env, ERL_NIF_TERM error,
 rocksdb::Status& status)
 {

--- a/c_src/util.h
+++ b/c_src/util.h
@@ -44,6 +44,7 @@ namespace erocksdb {
 
 ERL_NIF_TERM error_einval(ErlNifEnv* env);
 ERL_NIF_TERM error_tuple(ErlNifEnv* env, ERL_NIF_TERM error, rocksdb::Status& status);
+ERL_NIF_TERM status_to_term(ErlNifEnv* env, rocksdb::Status& status);
 ERL_NIF_TERM slice_to_binary(ErlNifEnv* env, rocksdb::Slice s);
 
 int binary_to_slice(ErlNifEnv* env, ERL_NIF_TERM val, rocksdb::Slice *slice);

--- a/src/rocksdb.erl
+++ b/src/rocksdb.erl
@@ -264,6 +264,7 @@
 -opaque statistics_handle() :: reference() | binary().
 
 -type column_family() :: cf_handle() | default_column_family.
+-type column_families() :: [cf_handle()].
 
 -type env_type() :: default | memenv.
 -opaque env() :: env_type() | env_handle().
@@ -1079,8 +1080,9 @@ flush(DbHandle, FlushOptions) ->
   flush(DbHandle, default_column_family, FlushOptions).
 
 %% @doc Flush all mem-table data for a column family
--spec flush(db_handle(), column_family(), flush_options()) -> ok | {error, term()}.
-flush(_DbHandle, _Cf, _FlushOptions) ->
+-spec flush(db_handle(), column_family() | column_families(), flush_options()) ->
+  ok | {error, term()}.
+flush(_DbHandle, _Cfs, _FlushOptions) ->
   ?nif_stub.
 
 %% @doc  Sync the wal. Note that Write() followed by SyncWAL() is not exactly the

--- a/src/rocksdb.erl
+++ b/src/rocksdb.erl
@@ -237,8 +237,8 @@
           target_size :: non_neg_integer()}).
 
 -type cf_descriptor() :: {string(), cf_options()}.
--type cache_type() :: lru | clock.
--type compression_type() :: snappy | zlib | bzip2 | lz4 | lz4h | zstd | none.
+-type cache_type() :: lru | clock.
+-type compression_type() :: snappy | zlib | bzip2 | lz4 | lz4h | zstd | none.
 -type compaction_style() :: level | universal | fifo | none.
 -type compaction_pri() :: compensated_size | oldest_largest_seq_first | oldest_smallest_seq_first.
 -type access_hint() :: normal | sequential | willneed | none.


### PR DESCRIPTION
Part of [EMQX-12468](https://emqx.atlassian.net/browse/EMQX-12468).

This is important use case when a DB is opened with `{atomic_flush, true}`.