### PR TITLE
Fix rocksdb opts

### DIFF
--- a/c_src/cache.cc
+++ b/c_src/cache.cc
@@ -17,7 +17,7 @@
 #include <array>
 
 #include "atoms.h"
-#include "rocksdb/cache.h"
+#include "rocksdb/advanced_cache.h"
 #include "cache.h"
 #include "util.h"
 
@@ -47,7 +47,7 @@ Cache::CacheResourceCleanup(ErlNifEnv * /*env*/, void * arg)
 
 
 Cache *
-Cache::CreateCacheResource(std::shared_ptr<rocksdb::Cache> cache)
+Cache::CreateCacheResource(std::shared_ptr<rocksdb::BlockCache> cache)
 {
     Cache * ret_ptr;
     void * alloc_ptr;
@@ -66,7 +66,7 @@ Cache::RetrieveCacheResource(ErlNifEnv * Env, const ERL_NIF_TERM & CacheTerm)
     return ret_ptr;
 }
 
-Cache::Cache(std::shared_ptr<rocksdb::Cache> Cache) : cache_(Cache) {}
+Cache::Cache(std::shared_ptr<rocksdb::BlockCache> cache) : cache_(cache) {}
 
 Cache::~Cache()
 {
@@ -77,7 +77,7 @@ Cache::~Cache()
     return;
 }
 
-std::shared_ptr<rocksdb::Cache> Cache::cache() {
+std::shared_ptr<rocksdb::BlockCache> Cache::cache() {
     auto c = cache_;
     return c;
 }
@@ -90,7 +90,7 @@ NewCache(
 {
     ErlNifUInt64 capacity;
     Cache *cache_ptr;
-    std::shared_ptr<rocksdb::Cache> cache;
+    std::shared_ptr<rocksdb::BlockCache> cache;
 
     if (!enif_is_atom(env, argv[0]) || !enif_get_uint64(env, argv[1], &capacity))
         return enif_make_badarg(env);
@@ -117,7 +117,7 @@ ERL_NIF_TERM
 ReleaseCache(ErlNifEnv *env, int /*argc*/, const ERL_NIF_TERM argv[])
 {
     Cache *cache_ptr;
-    std::shared_ptr<rocksdb::Cache> cache;
+    std::shared_ptr<rocksdb::BlockCache> cache;
 
     cache_ptr = erocksdb::Cache::RetrieveCacheResource(env, argv[0]);
     if (nullptr == cache_ptr)
@@ -132,7 +132,7 @@ ReleaseCache(ErlNifEnv *env, int /*argc*/, const ERL_NIF_TERM argv[])
 ERL_NIF_TERM
 cache_info_1(
     ErlNifEnv *env,
-    std::shared_ptr<rocksdb::Cache> cache,
+    std::shared_ptr<rocksdb::BlockCache> cache,
     ERL_NIF_TERM item)
 {
     if (item == erocksdb::ATOM_USAGE) {
@@ -157,7 +157,7 @@ CacheInfo(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
 
     Cache *cache_ptr;
-    std::shared_ptr<rocksdb::Cache> cache;
+    std::shared_ptr<rocksdb::BlockCache> cache;
 
     cache_ptr = erocksdb::Cache::RetrieveCacheResource(env, argv[0]);
     if (nullptr == cache_ptr)
@@ -192,7 +192,7 @@ ERL_NIF_TERM
 SetCapacity(ErlNifEnv * env, int /*argc*/, const ERL_NIF_TERM argv[])
 {
     Cache *cache_ptr;
-    std::shared_ptr<rocksdb::Cache> cache;
+    std::shared_ptr<rocksdb::BlockCache> cache;
     ErlNifUInt64 capacity;
 
     cache_ptr = erocksdb::Cache::RetrieveCacheResource(env, argv[0]);
@@ -212,7 +212,7 @@ ERL_NIF_TERM
 SetStrictCapacityLimit(ErlNifEnv * env, int /*argc*/, const ERL_NIF_TERM argv[])
 {
     Cache *cache_ptr;
-    std::shared_ptr<rocksdb::Cache> cache;
+    std::shared_ptr<rocksdb::BlockCache> cache;
     bool strict_capacity_limit;
     cache_ptr = erocksdb::Cache::RetrieveCacheResource(env, argv[0]);
     if (nullptr == cache_ptr)

--- a/c_src/cache.h
+++ b/c_src/cache.h
@@ -19,10 +19,7 @@
 #include <memory>
 
 #include "erl_nif.h"
-
-namespace rocksdb {
-    class Cache;
-}
+#include "rocksdb/advanced_cache.h"
 
 namespace erocksdb {
 
@@ -33,20 +30,20 @@ namespace erocksdb {
     public:
       std::mutex mu;
 
-      explicit Cache(std::shared_ptr<rocksdb::Cache> cache);
+      explicit Cache(std::shared_ptr<rocksdb::BlockCache> cache);
 
       ~Cache();
 
-      std::shared_ptr<rocksdb::Cache> cache();
+      std::shared_ptr<rocksdb::BlockCache> cache();
 
       static void CreateCacheType(ErlNifEnv * Env);
       static void CacheResourceCleanup(ErlNifEnv *Env, void * Arg);
 
-      static Cache * CreateCacheResource(std::shared_ptr<rocksdb::Cache> cache);
+      static Cache * CreateCacheResource(std::shared_ptr<rocksdb::BlockCache> cache);
       static Cache * RetrieveCacheResource(ErlNifEnv * Env, const ERL_NIF_TERM & CacheTerm);
 
     private:
-      std::shared_ptr<rocksdb::Cache> cache_;
+      std::shared_ptr<rocksdb::BlockCache> cache_;
   };
 
 }

--- a/c_src/erocksdb_db.cc
+++ b/c_src/erocksdb_db.cc
@@ -433,7 +433,7 @@ ERL_NIF_TERM parse_cf_option(ErlNifEnv* env, ERL_NIF_TERM item, rocksdb::ColumnF
         else if (option[0] == erocksdb::ATOM_COMPRESSION ||
                  option[0] == erocksdb::ATOM_BOTTOMMOST_COMPRESSION)
         {
-            rocksdb::CompressionType compression;
+            rocksdb::CompressionType compression = rocksdb::CompressionType::kNoCompression;
             if (option[1] == erocksdb::ATOM_COMPRESSION_TYPE_SNAPPY) {
                 compression = rocksdb::CompressionType::kSnappyCompression;
             }

--- a/c_src/rate_limiter.cc
+++ b/c_src/rate_limiter.cc
@@ -62,7 +62,7 @@ RateLimiter::RetrieveRateLimiterResource(ErlNifEnv * Env, const ERL_NIF_TERM & R
     return ret_ptr;
 }
 
-RateLimiter::RateLimiter(std::shared_ptr<rocksdb::RateLimiter> RateLimiter) : rate_limiter_(RateLimiter) {}
+RateLimiter::RateLimiter(std::shared_ptr<rocksdb::RateLimiter> ratelimiter) : rate_limiter_(ratelimiter) {}
 
 RateLimiter::~RateLimiter()
 {

--- a/rebar.config
+++ b/rebar.config
@@ -18,8 +18,8 @@
 {pre_hooks, [{clean, "rm -f priv/*.so"},
              {clean, "rm -rf _build/cmake"},
              {compile, "git submodule update --init"},
-             {"(linux|darwin|solaris)", compile, "./do_cmake.sh -DWITH_BUNDLE_LZ4=ON -DWITH_BUNDLE_SNAPPY=ON"},
-             {"(freebsd|netbsd|openbsd)", compile, "./do_cmake.sh -DWITH_BUNDLE_LZ4=ON -DWITH_BUNDLE_SNAPPY=ON"},
+             {"(linux|darwin|solaris)", compile, "./do_cmake.sh ${ERLANG_ROCKSDB_OPTS:- -DWITH_BUNDLE_LZ4=ON -DWITH_BUNDLE_SNAPPY=ON}"},
+             {"(freebsd|netbsd|openbsd)", compile, "./do_cmake.sh ${ERLANG_ROCKSDB_OPTS:- -DWITH_BUNDLE_LZ4=ON -DWITH_BUNDLE_SNAPPY=ON}"},
              {"win32", compile, "mkdir _build\\cmake & cd _build\\cmake & cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DWITH_BUNDLE_LZ4=ON -DWITH_BUNDLE_SNAPPY=ON ..\\..\\c_src"}
             ]}.
 


### PR DESCRIPTION
EMQX upstream had lost the functionality to build with a dynamically loaded rocksdb library. This restores it and fixes C++ build issues on Ubuntu 24.