### PR TITLE
Fix rocksdb compilation

### DIFF
--- a/c_src/cache.cc
+++ b/c_src/cache.cc
@@ -17,7 +17,6 @@
 #include <array>
 
 #include "atoms.h"
-#include "rocksdb/cache.h"
 #include "cache.h"
 #include "util.h"
 
@@ -47,7 +46,7 @@ Cache::CacheResourceCleanup(ErlNifEnv * /*env*/, void * arg)
 
 
 Cache *
-Cache::CreateCacheResource(std::shared_ptr<rocksdb::Cache> cache)
+Cache::CreateCacheResource(RocksDBCachePtr cache)
 {
     Cache * ret_ptr;
     void * alloc_ptr;
@@ -66,7 +65,7 @@ Cache::RetrieveCacheResource(ErlNifEnv * Env, const ERL_NIF_TERM & CacheTerm)
     return ret_ptr;
 }
 
-Cache::Cache(std::shared_ptr<rocksdb::Cache> Cache) : cache_(Cache) {}
+Cache::Cache(RocksDBCachePtr cache) : cache_(cache) {}
 
 Cache::~Cache()
 {
@@ -77,7 +76,7 @@ Cache::~Cache()
     return;
 }
 
-std::shared_ptr<rocksdb::Cache> Cache::cache() {
+RocksDBCachePtr Cache::cache() {
     auto c = cache_;
     return c;
 }
@@ -90,7 +89,7 @@ NewCache(
 {
     ErlNifUInt64 capacity;
     Cache *cache_ptr;
-    std::shared_ptr<rocksdb::Cache> cache;
+    RocksDBCachePtr cache;
 
     if (!enif_is_atom(env, argv[0]) || !enif_get_uint64(env, argv[1], &capacity))
         return enif_make_badarg(env);
@@ -117,7 +116,7 @@ ERL_NIF_TERM
 ReleaseCache(ErlNifEnv *env, int /*argc*/, const ERL_NIF_TERM argv[])
 {
     Cache *cache_ptr;
-    std::shared_ptr<rocksdb::Cache> cache;
+    RocksDBCachePtr cache;
 
     cache_ptr = erocksdb::Cache::RetrieveCacheResource(env, argv[0]);
     if (nullptr == cache_ptr)
@@ -132,7 +131,7 @@ ReleaseCache(ErlNifEnv *env, int /*argc*/, const ERL_NIF_TERM argv[])
 ERL_NIF_TERM
 cache_info_1(
     ErlNifEnv *env,
-    std::shared_ptr<rocksdb::Cache> cache,
+    RocksDBCachePtr cache,
     ERL_NIF_TERM item)
 {
     if (item == erocksdb::ATOM_USAGE) {
@@ -157,7 +156,7 @@ CacheInfo(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
 
     Cache *cache_ptr;
-    std::shared_ptr<rocksdb::Cache> cache;
+    RocksDBCachePtr cache;
 
     cache_ptr = erocksdb::Cache::RetrieveCacheResource(env, argv[0]);
     if (nullptr == cache_ptr)
@@ -192,7 +191,7 @@ ERL_NIF_TERM
 SetCapacity(ErlNifEnv * env, int /*argc*/, const ERL_NIF_TERM argv[])
 {
     Cache *cache_ptr;
-    std::shared_ptr<rocksdb::Cache> cache;
+    RocksDBCachePtr cache;
     ErlNifUInt64 capacity;
 
     cache_ptr = erocksdb::Cache::RetrieveCacheResource(env, argv[0]);
@@ -212,7 +211,7 @@ ERL_NIF_TERM
 SetStrictCapacityLimit(ErlNifEnv * env, int /*argc*/, const ERL_NIF_TERM argv[])
 {
     Cache *cache_ptr;
-    std::shared_ptr<rocksdb::Cache> cache;
+    RocksDBCachePtr cache;
     bool strict_capacity_limit;
     cache_ptr = erocksdb::Cache::RetrieveCacheResource(env, argv[0]);
     if (nullptr == cache_ptr)

--- a/c_src/cache.h
+++ b/c_src/cache.h
@@ -18,13 +18,22 @@
 #include <mutex>
 #include <memory>
 
+#include "rocksdb/version.h"
+#if ROCKSDB_MAJOR < 8
+#include "rocksdb/cache.h"
+#else
+#include "rocksdb/advanced_cache.h"
+#endif
+
 #include "erl_nif.h"
 
-namespace rocksdb {
-    class Cache;
-}
-
 namespace erocksdb {
+
+#if ROCKSDB_MAJOR < 8
+  typedef std::shared_ptr<rocksdb::Cache> RocksDBCachePtr;
+#else
+  typedef std::shared_ptr<rocksdb::BlockCache> RocksDBCachePtr;
+#endif
 
   class Cache {
     protected:
@@ -33,20 +42,20 @@ namespace erocksdb {
     public:
       std::mutex mu;
 
-      explicit Cache(std::shared_ptr<rocksdb::Cache> cache);
+      explicit Cache(RocksDBCachePtr cache);
 
       ~Cache();
 
-      std::shared_ptr<rocksdb::Cache> cache();
+      RocksDBCachePtr cache();
 
       static void CreateCacheType(ErlNifEnv * Env);
       static void CacheResourceCleanup(ErlNifEnv *Env, void * Arg);
 
-      static Cache * CreateCacheResource(std::shared_ptr<rocksdb::Cache> cache);
+      static Cache * CreateCacheResource(RocksDBCachePtr cache);
       static Cache * RetrieveCacheResource(ErlNifEnv * Env, const ERL_NIF_TERM & CacheTerm);
 
     private:
-      std::shared_ptr<rocksdb::Cache> cache_;
+      RocksDBCachePtr cache_;
   };
 
 }

--- a/c_src/erocksdb_db.cc
+++ b/c_src/erocksdb_db.cc
@@ -433,7 +433,7 @@ ERL_NIF_TERM parse_cf_option(ErlNifEnv* env, ERL_NIF_TERM item, rocksdb::ColumnF
         else if (option[0] == erocksdb::ATOM_COMPRESSION ||
                  option[0] == erocksdb::ATOM_BOTTOMMOST_COMPRESSION)
         {
-            rocksdb::CompressionType compression;
+            rocksdb::CompressionType compression = rocksdb::CompressionType::kNoCompression;
             if (option[1] == erocksdb::ATOM_COMPRESSION_TYPE_SNAPPY) {
                 compression = rocksdb::CompressionType::kSnappyCompression;
             }

--- a/c_src/rate_limiter.cc
+++ b/c_src/rate_limiter.cc
@@ -62,7 +62,7 @@ RateLimiter::RetrieveRateLimiterResource(ErlNifEnv * Env, const ERL_NIF_TERM & R
     return ret_ptr;
 }
 
-RateLimiter::RateLimiter(std::shared_ptr<rocksdb::RateLimiter> RateLimiter) : rate_limiter_(RateLimiter) {}
+RateLimiter::RateLimiter(std::shared_ptr<rocksdb::RateLimiter> ratelimiter) : rate_limiter_(ratelimiter) {}
 
 RateLimiter::~RateLimiter()
 {

--- a/rebar.config
+++ b/rebar.config
@@ -18,8 +18,8 @@
 {pre_hooks, [{clean, "rm -f priv/*.so"},
              {clean, "rm -rf _build/cmake"},
              {compile, "git submodule update --init"},
-             {"(linux|darwin|solaris)", compile, "./do_cmake.sh -DWITH_BUNDLE_LZ4=ON -DWITH_BUNDLE_SNAPPY=ON"},
-             {"(freebsd|netbsd|openbsd)", compile, "./do_cmake.sh -DWITH_BUNDLE_LZ4=ON -DWITH_BUNDLE_SNAPPY=ON"},
+             {"(linux|darwin|solaris)", compile, "./do_cmake.sh ${ERLANG_ROCKSDB_OPTS:- -DWITH_BUNDLE_LZ4=ON -DWITH_BUNDLE_SNAPPY=ON}"},
+             {"(freebsd|netbsd|openbsd)", compile, "./do_cmake.sh ${ERLANG_ROCKSDB_OPTS:- -DWITH_BUNDLE_LZ4=ON -DWITH_BUNDLE_SNAPPY=ON}"},
              {"win32", compile, "mkdir _build\\cmake & cd _build\\cmake & cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DWITH_BUNDLE_LZ4=ON -DWITH_BUNDLE_SNAPPY=ON ..\\..\\c_src"}
             ]}.
 


### PR DESCRIPTION
The EMQX fork of RocksDB had lost the functionality to build with a dynamically loaded rocksdb library (see 7a65dc5b86e). This restores it and also fixes C++ build issues on Ubuntu 24 and makes the code compile both against RocksDB 7 and RocksDB 8.