### PR TITLE
ci: test and release builds under Erlang/OTP 26 / 27

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,52 +15,33 @@ jobs:
       fail-fast: false
       matrix:
         otp:
-          - 25.3.2-2
-          - 26.2.1-2
+          - "25.3"
+          - "26.2"
+        rebar3:
+          - "3.20.0"
         os:
           - macos-14
           - macos-13
     runs-on: ${{ matrix.os }}
     steps:
-      - name: prepare
-        run: |
-          brew install curl zip unzip gnu-sed kerl wget
-          git config --global credential.helper store
-      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        id: cache
-        with:
-          path: ~/.kerl/${{ matrix.otp }}
-          key: otp-install-${{ matrix.otp }}-${{ matrix.os }}
-
-      - name: build erlang
-        if: steps.cache.outputs.cache-hit != 'true'
-        timeout-minutes: 60
+      - name: prepare erlang
         env:
-          OTP: ${{ matrix.otp }}
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
         run: |
-          set -eux
-          if [ ! -d $HOME/.kerl/$OTP ]; then
-            kerl build git https://github.com/emqx/otp.git OTP-$OTP $OTP
-            kerl install $OTP $HOME/.kerl/$OTP
-          fi
+          brew install erlang@${{ matrix.otp }}
+          echo "$(brew --prefix erlang@${{ matrix.otp }})/bin" >> $GITHUB_PATH
+
+      - name: install rebar3
+        run: |
+          wget https://github.com/erlang/rebar3/releases/download/${{ matrix.rebar3 }}/rebar3 && chmod +x rebar3
+          sudo mv rebar3 /usr/local/bin/ && sudo chmod +x /usr/local/bin/rebar3
 
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           ref: ${{ github.event.inputs.ref }}
 
-      - name: install rebar3
-        run: |
-          set -eux
-          REBAR=$(brew --prefix)/bin/rebar3
-          if [ ! -f $REBAR ]; then
-            wget https://s3.amazonaws.com/rebar3/rebar3 -O $REBAR
-            chmod +x $REBAR
-          fi
-
       - name: build
-        run: |
-          . $HOME/.kerl/${{ matrix.otp }}/activate
-          BUILD_RELEASE=1 make
+        run: env BUILD_RELEASE=1 make
 
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -103,7 +103,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && github.eventname != 'workflow_dispatch'
+    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - mac
       - linux

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,19 +15,20 @@ jobs:
       fail-fast: false
       matrix:
         otp:
-          - "25.3"
-          - "26.2"
+          - "26"
+          - "27"
         rebar3:
-          - "3.20.0"
+          - "3.22.0"
         os:
           - macos-14
-          - macos-13
+          - macos-15
     runs-on: ${{ matrix.os }}
     steps:
       - name: prepare erlang
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
         run: |
+          brew update
           brew install erlang@${{ matrix.otp }}
           echo "$(brew --prefix erlang@${{ matrix.otp }})/bin" >> $GITHUB_PATH
 
@@ -54,9 +55,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp:
-          - 25.3.2-2
-          - 26.2.1-2
+        erlang:
+          - otp: "26.2.5.2"
+            builder: "5.4-3:1.15.7-26.2.5.2-2"
+          - otp: "27.2"
+            builder: "5.4-3:1.17.3-27.2-1"
         arch:
           - amd64
           - arm64
@@ -86,7 +89,7 @@ jobs:
         #       for github actions
       - name: build
         env:
-          IMAGE: ghcr.io/emqx/emqx-builder/5.3-5:1.15.7-${{ matrix.otp }}-${{ matrix.os }}
+          IMAGE: ghcr.io/emqx/emqx-builder/${{ matrix.erlang.builder }}-${{ matrix.os }}
         run: >-
           docker run --rm -v ${PWD}:/wd ${IMAGE} bash -euc "
           git config --global --add safe.directory '*';
@@ -96,7 +99,7 @@ jobs:
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: erlang-rocksdb-nif-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.otp }}
+          name: erlang-rocksdb-nif-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.erlang.otp }}
           path: |
             _packages/*.gz
             _packages/*.gz.sha256

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,9 +4,33 @@ on:
   pull_request:
 
 jobs:
+  macos:
+    strategy:
+      matrix:
+        otp:
+          - "26.2"
+        rebar3:
+          - "3.20.0"
+    runs-on: macos-14
+    steps:
+      - name: prepare
+        env:
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
+        run: |
+          brew install erlang@${{ matrix.otp }}
+          echo "$(brew --prefix erlang@${{ matrix.otp }})/bin" >> $GITHUB_PATH
+      - name: install rebar3
+        run: |
+          wget https://github.com/erlang/rebar3/releases/download/${{ matrix.rebar3 }}/rebar3 && chmod +x rebar3
+          sudo mv rebar3 /usr/local/bin/ && sudo chmod +x /usr/local/bin/rebar3
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          submodules: recursive
+      - name: test build
+        run: make
+
   linux:
     strategy:
-      fail-fast: false
       matrix:
         builder:
           - 5.3-5:1.15.7-26.2.1-2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,15 +8,16 @@ jobs:
     strategy:
       matrix:
         otp:
-          - "26.2"
+          - "27"
         rebar3:
-          - "3.20.0"
-    runs-on: macos-14
+          - "3.22.0"
+    runs-on: macos-15
     steps:
       - name: prepare
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
         run: |
+          brew update
           brew install erlang@${{ matrix.otp }}
           echo "$(brew --prefix erlang@${{ matrix.otp }})/bin" >> $GITHUB_PATH
       - name: install rebar3
@@ -33,9 +34,10 @@ jobs:
     strategy:
       matrix:
         builder:
-          - 5.3-5:1.15.7-26.2.1-2
+          - 5.4-3:1.17.3-27.2-1
         os:
           - ubuntu24.04
+
     runs-on: ubuntu-24.04
 
     container: ghcr.io/emqx/emqx-builder/${{ matrix.builder }}-${{ matrix.os }}


### PR DESCRIPTION
Also:
* Test and release macOS builds under vanilla Erlang/OTP.
* Allow rerunning release pipeline for existing tags.

See individual commits for details.