### PR TITLE
ci: enable rereleases of arbitrary tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ on:
     inputs:
       ref:
         required: false
+      ref_name:
+        required: false
 
 jobs:
   mac:
@@ -97,7 +99,6 @@ jobs:
           "
 
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           name: erlang-rocksdb-nif-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.erlang.otp }}
           path: |
@@ -106,7 +107,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event.inputs.ref_name || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     needs:
       - mac
       - linux
@@ -119,7 +120,8 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
         with:
-          name: Erlang Rocksdb NIF ${{ github.ref_name }} Released
+          name: Erlang Rocksdb NIF ${{ github.event.inputs.ref_name || github.ref_name }} Released
+          tag_name: ${{ github.event.inputs.ref_name || github.ref_name }}
           files: packages/*
           draft: false
           prerelease: false


### PR DESCRIPTION
Might be useful if one wants to provide prebuilt binaries for existing tags/releases, but built under more recent Erlang/OTP versions.