### PR TITLE
fix shasum verification on macos

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
         rebar3:
           - "3.22.0"
         os:
+          - macos-13
           - macos-14
           - macos-15
     runs-on: ${{ matrix.os }}

--- a/download.sh
+++ b/download.sh
@@ -15,7 +15,13 @@ if [ ! -f "_packages/${PKGNAME}.sha256" ]; then
     curl -f -L --no-progress-meter -o "_packages/${PKGNAME}.sha256" "${URL}.sha256"
 fi
 
-echo "$(cat "_packages/${PKGNAME}.sha256") _packages/${PKGNAME}" | sha256sum -c || exit 1
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    # macOS
+    echo "$(cat "_packages/${PKGNAME}.sha256")  _packages/${PKGNAME}" | shasum -a 256 -c || exit 1
+else
+    # Linux and other Unix-like systems
+    echo "$(cat "_packages/${PKGNAME}.sha256")  _packages/${PKGNAME}" | sha256sum -c || exit 1
+fi
 
 mkdir -p priv
 gzip -c -d "_packages/${PKGNAME}" > priv/liberocksdb.so


### PR DESCRIPTION
sha256sum on macOS is from BSD and has different options than GNU.

This leads to prebuilt packages not being used even when they exist
https://github.com/emqx/emqx/actions/runs/14439343361/job/40485949071#step:3:661
```
+ ./do_prebuilt.sh
usage: sha256sum [-bctwz] [files ...]
+ echo 'No prebuilt artifacts, building from source'
```

Fix this by explicitly using shasum instead of sha256sum when on macOS.