### PR TITLE
build: opt into a binary-compatible distro via ERLANG_ROCKSDB_DIST

### DIFF
--- a/pkgname.sh
+++ b/pkgname.sh
@@ -8,14 +8,21 @@ case "$UNAMES" in
         SYSTEM="$(echo "${DIST}${VERSION_ID}" | gsed -r 's/([a-zA-Z]*)-.*/\1/g')"
         ;;
     Linux)
-        if grep -q -i 'rhel' /etc/*-release; then
-            DIST='el'
-            VERSION_ID="$(rpm --eval '%{rhel}')"
+        if [ -n "${ERLANG_ROCKSDB_DIST:-}" ]; then
+            # Allow distros without a matching prebuilt to opt into a
+            # binary-compatible target. e.g. on Arch Linux:
+            #   ERLANG_ROCKSDB_DIST=debian13
+            SYSTEM="${ERLANG_ROCKSDB_DIST}"
         else
-            DIST="$(sed -n '/^ID=/p' /etc/os-release | sed -r 's/ID=(.*)/\1/g' | sed 's/"//g')"
-            VERSION_ID="$(sed -n '/^VERSION_ID=/p' /etc/os-release | sed -r 's/VERSION_ID=(.*)/\1/g' | sed 's/"//g')"
+            if grep -q -i 'rhel' /etc/*-release; then
+                DIST='el'
+                VERSION_ID="$(rpm --eval '%{rhel}')"
+            else
+                DIST="$(sed -n '/^ID=/p' /etc/os-release | sed -r 's/ID=(.*)/\1/g' | sed 's/"//g')"
+                VERSION_ID="$(sed -n '/^VERSION_ID=/p' /etc/os-release | sed -r 's/VERSION_ID=(.*)/\1/g' | sed 's/"//g')"
+            fi
+            SYSTEM="$(echo "${DIST}${VERSION_ID}" | sed -r 's/([a-zA-Z]*)-.*/\1/g')"
         fi
-        SYSTEM="$(echo "${DIST}${VERSION_ID}" | sed -r 's/([a-zA-Z]*)-.*/\1/g')"
         ;;
     *)
         echo ''


### PR DESCRIPTION
If wanted this script can be changed to automatically detect rolling release systems and try to go for the more stable releases that are compatible

pkgname.sh constructs the prebuilt asset name from /etc/os-release's ID/VERSION_ID. Distros not present in the release matrix (notably Arch Linux, where ID=arch and VERSION_ID is empty due to its rolling- release model) generate names like "arch-x86_64.gz" that do not exist as release assets, causing do_prebuilt.sh to fall through to a C++ source build.

Add an ERLANG_ROCKSDB_DIST escape hatch: when set, its value is used verbatim as the SYSTEM string. This lets users on unsupported distros opt into any ABI-compatible target without forking the build script:

```sh
 ERLANG_ROCKSDB_DIST=debian13 mix deps.compile rocksdb
```
The default detection path is unchanged when the variable is unset, so this is a strict superset of the prior behavior.